### PR TITLE
外部イメージのサイズを取得してimgタグに反映する

### DIFF
--- a/components/RehypeToReactElement/CustomComponents/CustomImage.tsx
+++ b/components/RehypeToReactElement/CustomComponents/CustomImage.tsx
@@ -5,38 +5,48 @@ type Props = {
   src: string;
   alt?: string;
   title?: string;
+  width?: string;
+  height?: string;
 };
 
-const CustomImage: React.VFC<Props> = (props) => {
+const CustomImage: React.VFC<Props> = ({ src, alt, title, width, height }) => {
   const isAmp = useAmp();
   return (
-    <div className="flex justify-center flex-col mt-5 img">
+    <div className="flex flex-col mt-5 img">
       {isAmp ? (
-        <figure className="ampImgFixedContainer">
+        <figure
+          className={
+            width && height
+              ? "flex justify-center max-h-96 w-full"
+              : "ampImgFixedContainer"
+          }
+        >
           <amp-img
             className="contain"
-            src={props.src}
-            layout="fill"
-            alt={props.alt}
-            title={props.title}
+            src={src}
+            layout={width && height ? "intrinsic" : "fill"}
+            alt={alt}
+            title={title}
+            width={width}
+            height={height}
           />
         </figure>
       ) : (
-        <figure className="flex justify-center">
+        <figure className="flex justify-center max-h-96">
           <Image
-            src={props.src}
-            alt={props.alt}
-            title={props.title}
-            width="500"
-            height="350"
+            src={src}
+            alt={alt}
+            title={title}
+            width={width || 500}
+            height={height || 384}
             loading="lazy"
             objectFit={"contain"}
           />
         </figure>
       )}
-      {props.title && (
+      {title && (
         <figcaption className="text-center text-xs text-gray-600 mt-1">
-          {props.title}
+          {title}
         </figcaption>
       )}
     </div>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "7.30.0",
     "eslint-config-next": "11.0.1",
     "gray-matter": "^4.0.3",
+    "image-size": "^1.0.0",
     "postcss": "^8.3.5",
     "postcss-cli": "^8.3.1",
     "postcss-preset-env": "^6.7.0",
@@ -35,11 +36,12 @@
     "remark-breaks": "^2.0.2",
     "remark-parse": "^9.0.0",
     "remark-rehype": "^8.1.0",
-    "tailwindcss": "^2.2.4",
-    "unified": "^9.2.1",
     "stylelint": "^13.13.1",
     "stylelint-config-recommended": "^5.0.0",
     "stylelint-order": "^4.1.0",
-    "typescript": "4.3.5"
+    "tailwindcss": "^2.2.4",
+    "typescript": "4.3.5",
+    "unified": "^9.2.1",
+    "unist-util-visit": "^2.0.2"
   }
 }

--- a/rehype-external-imsize/index.d.ts
+++ b/rehype-external-imsize/index.d.ts
@@ -1,0 +1,16 @@
+import { Plugin } from "unified";
+
+declare const rehypeImsize: Plugin<[RehypeImsizeOptions?]>;
+
+interface RehypeImsizeOptions {
+  /**
+   * ⚠️ The units should be specified in bytes.
+   * Optionally check the buffer length and stop downloading images after a few kilobytes.
+   * No need to download the entire image to get the dimensions.
+   *
+   * @default 1000
+   */
+  maxBufferLengths: number;
+}
+
+export = rehypeImsize;

--- a/rehype-external-imsize/index.js
+++ b/rehype-external-imsize/index.js
@@ -1,0 +1,74 @@
+const http = require("http");
+const https = require("https");
+
+const sizeOf = require("image-size");
+const visit = require("unist-util-visit");
+
+module.exports = rehypeImsize;
+
+function rehypeImsize(options) {
+  const opts = options || {};
+  const maxBufferLengths = opts.maxBufferLengths;
+
+  return transformer;
+
+  async function transformer(tree, _file) {
+    const promises = [];
+    visit(tree, "element", visitor);
+    await Promise.all(promises);
+
+    function visitor(node) {
+      if (node.tagName !== "img") {
+        return;
+      }
+
+      const src = node.properties.src;
+
+      if (!src.startsWith("http")) {
+        return;
+      }
+
+      const url = new URL(src);
+      const client = url.protocol === "https:" ? https : http;
+
+      const promise = new Promise(function (resolve) {
+        try {
+          client.get(url, function (response) {
+            const request = this;
+
+            const chunks = [];
+
+            function setImageSize() {
+              const buffer = Buffer.concat(chunks);
+              const dimensions = sizeOf(buffer);
+
+              node.properties.width = dimensions.width;
+              node.properties.height = dimensions.height;
+              resolve();
+            }
+
+            let bufferLengths = 0;
+
+            response
+              .on("data", function (chunk) {
+                chunks.push(chunk);
+                bufferLengths += chunk.length;
+
+                // stop downloading images after maxBufferLengths
+                if (maxBufferLengths && bufferLengths > maxBufferLengths) {
+                  request.destroy();
+                  setImageSize();
+                }
+              })
+              .on("end", setImageSize);
+          });
+        } catch (error) {
+          console.log(error);
+          resolve();
+        }
+      });
+
+      promises.push(promise);
+    }
+  }
+}

--- a/utils/transpiler.ts
+++ b/utils/transpiler.ts
@@ -5,13 +5,17 @@ import rehypeStringify from "rehype-stringify";
 import breaks from "remark-breaks";
 // @ts-ignore
 import rehypePrism from "@mapbox/rehype-prism";
+import rehypeImsize from "rehype-external-imsize";
 
-export const markdownToHtml = async (markdown: string) =>
-  unified()
+export const markdownToHtml = async (markdown: string) => {
+  const result = await unified()
     .use(remarkParse)
     .use(breaks)
     .use(remarkRehype)
+    .use(rehypeImsize, { maxBufferLengths: 1000 })
     .use(rehypePrism)
     .use(rehypeStringify)
-    .processSync(markdown)
-    .toString();
+    .process(markdown);
+
+  return result.toString();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,7 +2512,7 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-image-size@1.0.0:
+image-size@1.0.0, image-size@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.0.tgz#58b31fe4743b1cec0a0ac26f5c914d3c5b2f0750"
   integrity sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==
@@ -5653,7 +5653,7 @@ unist-util-visit@^1.4.1:
   dependencies:
     unist-util-visit-parents "^2.0.0"
 
-unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
+unist-util-visit@^2.0.0, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
CLS回避のため、サーバーサイドで画像サイズの寸法を計測してimgタグに反映する